### PR TITLE
Update WT2003S_Player.h

### DIFF
--- a/src/WT2003S_Player.h
+++ b/src/WT2003S_Player.h
@@ -140,4 +140,4 @@ class WT2003S {
     void getSPIFLashMp3Data(char* data, uint16_t address, uint16_t len);
 };
 
-#endif;
+#endif


### PR DESCRIPTION
Semicolon after endif gives warning: extra tokens at end of #endif directive in arduino studio.